### PR TITLE
[Feat]: Implement queue declare/ exchange declare api

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -31,6 +31,11 @@
             <artifactId>netty-all</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.aok</groupId>
+            <artifactId>meta</artifactId>
+            <version>1.0.0</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.qpid</groupId>
             <artifactId>qpid-broker-core</artifactId>
         </dependency>

--- a/core/src/main/java/com/aok/core/AmqpChannel.java
+++ b/core/src/main/java/com/aok/core/AmqpChannel.java
@@ -18,6 +18,16 @@
  */
 package com.aok.core;
 
+import com.aok.meta.Exchange;
+import com.aok.meta.ExchangeType;
+import com.aok.meta.Queue;
+import com.aok.meta.service.BindingService;
+import com.aok.meta.service.ExchangeService;
+import com.aok.meta.service.QueueService;
+import com.aok.meta.service.VhostService;
+import io.netty.util.internal.StringUtil;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.qpid.server.bytebuffer.QpidByteBuffer;
 import org.apache.qpid.server.protocol.v0_8.AMQShortString;
 import org.apache.qpid.server.protocol.v0_8.FieldTable;
@@ -29,15 +39,36 @@ import org.apache.qpid.server.protocol.v0_8.transport.QueueDeclareOkBody;
 import org.apache.qpid.server.protocol.v0_8.transport.QueueUnbindOkBody;
 import org.apache.qpid.server.protocol.v0_8.transport.ServerChannelMethodProcessor;
 
+@Slf4j
 public class AmqpChannel implements ServerChannelMethodProcessor {
     
-    protected AmqpConnection connection;
+    private final AmqpConnection connection;
+
+    @Getter
+    private final int channelId;
+
+    private final VhostService vhostService;
+
+    private final BindingService bindingService;
+
+    private final ExchangeService exchangeService;
+
+    private  final QueueService queueService;
     
-    protected int channelId;
-    
-    AmqpChannel(AmqpConnection connection, int channelId) {
+    AmqpChannel(
+        AmqpConnection connection,
+        int channelId,
+        VhostService vhostService,
+        ExchangeService exchangeService,
+        QueueService queueService,
+        BindingService bindingService
+    ) {
         this.connection = connection;
         this.channelId = channelId;
+        this.vhostService = vhostService;
+        this.exchangeService = exchangeService;
+        this.queueService = queueService;
+        this.bindingService = bindingService;
     }
 
     @Override
@@ -48,11 +79,20 @@ public class AmqpChannel implements ServerChannelMethodProcessor {
 
     @Override
     public void receiveExchangeDeclare(AMQShortString exchange, AMQShortString type, boolean passive, boolean durable, boolean autoDelete, boolean internal, boolean nowait, FieldTable arguments) {
+        String exchangeName = exchange == null ? StringUtil.EMPTY_STRING : exchange.toString();
+        String vhost = connection.getVhost();
+        exchangeService.addExchange(vhost, exchangeName, ExchangeType.value(AMQShortString.toString(type)), autoDelete, durable, internal, FieldTable.convertToMap(arguments));
         connection.writeFrame(connection.getRegistry().createExchangeDeclareOkBody().generateFrame(channelId));
     }
 
     @Override
     public void receiveExchangeDelete(AMQShortString exchange, boolean ifUnused, boolean nowait) {
+        String vhost = connection.getVhost();
+        Exchange cur = exchangeService.getExchange(vhost, AMQShortString.toString(exchange));
+        if (cur != null) {
+            exchangeService.deleteExchange(cur);
+            log.info("delete exchange {} success", exchange);
+        }
         connection.writeFrame(connection.getRegistry().createExchangeDeleteOkBody().generateFrame(channelId));
     }
 
@@ -65,7 +105,17 @@ public class AmqpChannel implements ServerChannelMethodProcessor {
 
     @Override
     public void receiveQueueDeclare(AMQShortString queue, boolean passive, boolean durable, boolean exclusive, boolean autoDelete, boolean nowait, FieldTable arguments) {
-        QueueDeclareOkBody responseBody = connection.getRegistry().createQueueDeclareOkBody(AMQShortString.createAMQShortString("name"), 1,1);
+        Queue q = queueService.addQueue(
+            connection.getVhost(),
+            AMQShortString.toString(queue),
+            exclusive,
+            durable,
+            autoDelete,
+            exclusive,
+            FieldTable.convertToMap(arguments)
+        );
+        log.info("queue declare success: {}", q);
+        QueueDeclareOkBody responseBody = connection.getRegistry().createQueueDeclareOkBody(AMQShortString.createAMQShortString(q.getName()), 0,0);
         connection.writeFrame(responseBody.generateFrame(channelId));
     }
 

--- a/core/src/main/java/com/aok/core/AmqpChannel.java
+++ b/core/src/main/java/com/aok/core/AmqpChannel.java
@@ -109,9 +109,8 @@ public class AmqpChannel implements ServerChannelMethodProcessor {
             connection.getVhost(),
             AMQShortString.toString(queue),
             exclusive,
-            durable,
             autoDelete,
-            exclusive,
+            durable,
             FieldTable.convertToMap(arguments)
         );
         log.info("queue declare success: {}", q);

--- a/meta/pom.xml
+++ b/meta/pom.xml
@@ -36,5 +36,9 @@
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/meta/src/main/java/com/aok/meta/Exchange.java
+++ b/meta/src/main/java/com/aok/meta/Exchange.java
@@ -17,18 +17,21 @@
 package com.aok.meta;
 
 import lombok.Data;
+import lombok.ToString;
 
-import java.util.HashMap;
+import java.util.Map;
 
 @Data
 @MetaType("exchange")
+@ToString
 public class Exchange extends Meta {
 
-    public Exchange(String vhost, String name, ExchangeType type, Boolean autoDelete, Boolean internal, HashMap<String, Object> arguments) {
+    public Exchange(String vhost, String name, ExchangeType type, Boolean autoDelete, Boolean durable, Boolean internal, Map<String, Object> arguments) {
         setVhost(vhost);
         setName(name);
         this.type = type;
         this.autoDelete = autoDelete;
+        this.durable = durable;
         this.internal = internal;
         this.arguments = arguments;
     }
@@ -41,5 +44,5 @@ public class Exchange extends Meta {
 
     private boolean internal;
 
-    private HashMap<String, Object> arguments;
+    private Map<String, Object> arguments;
 }

--- a/meta/src/main/java/com/aok/meta/Queue.java
+++ b/meta/src/main/java/com/aok/meta/Queue.java
@@ -25,7 +25,7 @@ import java.util.Map;
 @MetaType("queue")
 public class Queue extends Meta {
     
-    public Queue(String vhost, String name, Boolean exclusive, Boolean autoDelete, Boolean durable, Boolean internal, Map<String, Object> arguments) {
+    public Queue(String vhost, String name, Boolean exclusive, Boolean autoDelete, Boolean durable, Map<String, Object> arguments) {
         this.setVhost(vhost);
         this.setName(name);
         this.exclusive = exclusive;

--- a/meta/src/main/java/com/aok/meta/Queue.java
+++ b/meta/src/main/java/com/aok/meta/Queue.java
@@ -19,12 +19,13 @@ package com.aok.meta;
 import lombok.Data;
 
 import java.util.HashMap;
+import java.util.Map;
 
 @Data
 @MetaType("queue")
 public class Queue extends Meta {
     
-    public Queue(String vhost, String name, Boolean exclusive, Boolean autoDelete, Boolean durable, Boolean internal, HashMap<String, String> arguments) {
+    public Queue(String vhost, String name, Boolean exclusive, Boolean autoDelete, Boolean durable, Boolean internal, Map<String, Object> arguments) {
         this.setVhost(vhost);
         this.setName(name);
         this.exclusive = exclusive;
@@ -42,5 +43,5 @@ public class Queue extends Meta {
     
     private Boolean internal;
     
-    private HashMap<String, String> arguments;
+    private Map<String, Object> arguments;
 }

--- a/meta/src/main/java/com/aok/meta/Queue.java
+++ b/meta/src/main/java/com/aok/meta/Queue.java
@@ -31,7 +31,6 @@ public class Queue extends Meta {
         this.exclusive = exclusive;
         this.autoDelete = autoDelete;
         this.durable = durable;
-        this.internal = internal;
         this.arguments = arguments;
     }
     
@@ -40,8 +39,6 @@ public class Queue extends Meta {
     private Boolean exclusive;
     
     private Boolean autoDelete;
-    
-    private Boolean internal;
     
     private Map<String, Object> arguments;
 }

--- a/meta/src/main/java/com/aok/meta/service/ExchangeService.java
+++ b/meta/src/main/java/com/aok/meta/service/ExchangeService.java
@@ -21,17 +21,18 @@ import com.aok.meta.ExchangeType;
 import com.aok.meta.container.MetaContainer;
 
 import java.util.HashMap;
+import java.util.Map;
 
 public class ExchangeService {
 
     private final MetaContainer<Exchange> metaContainer;
 
-    ExchangeService(MetaContainer<Exchange> metaContainer) {
+    public ExchangeService(MetaContainer<Exchange> metaContainer) {
         this.metaContainer = metaContainer;
     }
 
-    public Exchange addExchange(String vhost, String name, ExchangeType exchangeType, Boolean autoDelete, Boolean internal, HashMap<String, Object> arguments) {
-        Exchange exchange = new Exchange(vhost, name, exchangeType, autoDelete, internal, arguments);
+    public Exchange addExchange(String vhost, String name, ExchangeType exchangeType, Boolean autoDelete, Boolean durable, Boolean internal, Map<String, Object> arguments) {
+        Exchange exchange = new Exchange(vhost, name, exchangeType, autoDelete, durable, internal, arguments);
         return (Exchange) metaContainer.add(exchange);
     }
 

--- a/meta/src/main/java/com/aok/meta/service/QueueService.java
+++ b/meta/src/main/java/com/aok/meta/service/QueueService.java
@@ -31,7 +31,7 @@ public class QueueService {
     }
     
     public Queue addQueue(String vhost, String name, Boolean exclusive, Boolean autoDelete, Boolean durable, Map<String, Object> arguments) {
-        Queue queue = new Queue(vhost, name, exclusive, autoDelete, durable, internal, arguments);
+        Queue queue = new Queue(vhost, name, exclusive, autoDelete, durable, arguments);
         return (Queue) metaContainer.add(queue);
     }
     

--- a/meta/src/main/java/com/aok/meta/service/QueueService.java
+++ b/meta/src/main/java/com/aok/meta/service/QueueService.java
@@ -30,7 +30,7 @@ public class QueueService {
         this.metaContainer = metaContainer;
     }
     
-    public Queue addQueue(String vhost, String name, Boolean exclusive, Boolean autoDelete, Boolean durable, Boolean internal, Map<String, Object> arguments) {
+    public Queue addQueue(String vhost, String name, Boolean exclusive, Boolean autoDelete, Boolean durable, Map<String, Object> arguments) {
         Queue queue = new Queue(vhost, name, exclusive, autoDelete, durable, internal, arguments);
         return (Queue) metaContainer.add(queue);
     }

--- a/meta/src/main/java/com/aok/meta/service/QueueService.java
+++ b/meta/src/main/java/com/aok/meta/service/QueueService.java
@@ -19,8 +19,8 @@ package com.aok.meta.service;
 import com.aok.meta.Queue;
 import com.aok.meta.container.MetaContainer;
 
-import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class QueueService {
     
@@ -30,9 +30,9 @@ public class QueueService {
         this.metaContainer = metaContainer;
     }
     
-    public void addQueue(String vhost, String name, Boolean exclusive, Boolean autoDelete, Boolean durable, Boolean internal, HashMap<String, String> arguments) {
+    public Queue addQueue(String vhost, String name, Boolean exclusive, Boolean autoDelete, Boolean durable, Boolean internal, Map<String, Object> arguments) {
         Queue queue = new Queue(vhost, name, exclusive, autoDelete, durable, internal, arguments);
-        metaContainer.add(queue);
+        return (Queue) metaContainer.add(queue);
     }
     
     public Queue deleteQueue(Queue queue) {

--- a/meta/src/main/java/com/aok/meta/service/VhostService.java
+++ b/meta/src/main/java/com/aok/meta/service/VhostService.java
@@ -25,7 +25,7 @@ public class VhostService {
 
     private final MetaContainer<Vhost> metaContainer;
 
-    VhostService(MetaContainer<Vhost> metaContainer) {
+    public VhostService(MetaContainer<Vhost> metaContainer) {
         this.metaContainer = metaContainer;
     }
 

--- a/meta/src/test/java/com/aok/meta/container/InMemoryMetaContainerTest.java
+++ b/meta/src/test/java/com/aok/meta/container/InMemoryMetaContainerTest.java
@@ -21,8 +21,8 @@ class InMemoryMetaContainerTest {
         String vhost1 = "testVhost";
         String nameQ1 = "testName";
         String nameQ2 = "testName2";
-        Queue q1 = new Queue(vhost1, nameQ1, false, false, true, false, null);
-        Queue q2 = new Queue(vhost1, nameQ2, false, false, true, false, null);
+        Queue q1 = new Queue(vhost1, nameQ1, false, false, true, null);
+        Queue q2 = new Queue(vhost1, nameQ2, false, false, true, null);
         inMemoryMetaContainer.add(q1);
         inMemoryMetaContainer.add(q2);
         Queue getQueue1 = (Queue) inMemoryMetaContainer.get(Queue.class, vhost1, nameQ1);


### PR DESCRIPTION
This pull request introduces integration between the core AMQP broker implementation and the new metadata management module (`meta`). The changes refactor the broker's channel and connection handling to utilize services for managing exchanges, queues, bindings, and virtual hosts, and update the construction and usage of these metadata objects throughout the codebase.

**Core Integration and Refactoring:**

* The `core` module now depends on the new `meta` module, and the AMQP broker (`Broker`, `AmqpConnection`, and `AmqpChannel`) is refactored to use `VhostService`, `ExchangeService`, `QueueService`, and `BindingService` for all metadata operations. Services are instantiated and injected throughout the broker lifecycle, ensuring that all exchange and queue declarations, deletions, and queries are handled via the new metadata layer. [[1]](diffhunk://#diff-8d04401f1cc51365fe3e32f019cd720135ba920a1a7da7f19e9c9208478701fcR33-R37) [[2]](diffhunk://#diff-d226f5b951ee02aca2b81357d778ee7173ced241f80292137b3d13b67a6a7fd9R19-R25) [[3]](diffhunk://#diff-d226f5b951ee02aca2b81357d778ee7173ced241f80292137b3d13b67a6a7fd9R54-R60) [[4]](diffhunk://#diff-d226f5b951ee02aca2b81357d778ee7173ced241f80292137b3d13b67a6a7fd9L59-R73) [[5]](diffhunk://#diff-6d238076033b39a87848551d27416271103b3fbc4864c24e95bb79501301c676R19-R22) [[6]](diffhunk://#diff-6d238076033b39a87848551d27416271103b3fbc4864c24e95bb79501301c676R51-R81) [[7]](diffhunk://#diff-6d238076033b39a87848551d27416271103b3fbc4864c24e95bb79501301c676R106-R114) [[8]](diffhunk://#diff-6d238076033b39a87848551d27416271103b3fbc4864c24e95bb79501301c676L185-L194) [[9]](diffhunk://#diff-638be9e3ff586ae46e120446f8446106f1023c1c9a31db05dfbfce44461f9900R21-R30) [[10]](diffhunk://#diff-638be9e3ff586ae46e120446f8446106f1023c1c9a31db05dfbfce44461f9900R42-R71)

**AMQP Protocol Handling Improvements:**

* `AmqpChannel` and `AmqpConnection` are refactored to use constructor-based dependency injection for all metadata services, and now interact with these services for exchange/queue creation and deletion. Logging is added for key events (e.g., exchange/queue creation and deletion). [[1]](diffhunk://#diff-638be9e3ff586ae46e120446f8446106f1023c1c9a31db05dfbfce44461f9900R42-R71) [[2]](diffhunk://#diff-638be9e3ff586ae46e120446f8446106f1023c1c9a31db05dfbfce44461f9900R82-R95) [[3]](diffhunk://#diff-638be9e3ff586ae46e120446f8446106f1023c1c9a31db05dfbfce44461f9900L68-R118) [[4]](diffhunk://#diff-6d238076033b39a87848551d27416271103b3fbc4864c24e95bb79501301c676R106-R114)

**Metadata Model and Service Updates:**

* The `Exchange` and `Queue` classes in `meta` are updated to use `Map<String, Object>` for arguments instead of `HashMap`, and their constructors are updated accordingly. The `ExchangeService` and `QueueService` methods are modified to reflect these changes and to return the created objects. [[1]](diffhunk://#diff-714f0e45bb3335a9f71b7de7f81689bb36d0f5641d33d7273d7b14960274a6a1R20-R34) [[2]](diffhunk://#diff-714f0e45bb3335a9f71b7de7f81689bb36d0f5641d33d7273d7b14960274a6a1L44-R47) [[3]](diffhunk://#diff-199655f63831de250792358e8975d37d3e9a6caf5f43b1952c7375c1b156282eR22-R28) [[4]](diffhunk://#diff-199655f63831de250792358e8975d37d3e9a6caf5f43b1952c7375c1b156282eL45-R46) [[5]](diffhunk://#diff-092eb2fe2361465686486104abe2c91cdbbca5cfd506e264c81a581fb8d23fabR24-R35) [[6]](diffhunk://#diff-ce6f9a40069b2fe4cc73a8e841e86e44253133b805eff959bb168ba36973b1fbL22-R23) [[7]](diffhunk://#diff-ce6f9a40069b2fe4cc73a8e841e86e44253133b805eff959bb168ba36973b1fbL33-R35)

**Dependency and Utility Enhancements:**

* The `meta` module now declares a dependency on Lombok for boilerplate code reduction.

**API Visibility and Construction:**

* Service constructors in the `meta` module are made public to allow instantiation from the core broker. [[1]](diffhunk://#diff-092eb2fe2361465686486104abe2c91cdbbca5cfd506e264c81a581fb8d23fabR24-R35) [[2]](diffhunk://#diff-ce6f9a40069b2fe4cc73a8e841e86e44253133b805eff959bb168ba36973b1fbL33-R35) [[3]](diffhunk://#diff-55c8cff393951351b7691d231dcf4df7d1fd45beda1057a66dec726acad2f770L28-R28)